### PR TITLE
Giving access to the commentOnlyChangedContentContext parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Missing a format? Open an issue [here](https://github.com/tomasbjerre/violations
                                                         Default: true
 -comment-only-changed-content, -cocc <boolean>          <boolean>: true or false
                                                         Default: true
--comment-only-changed-content-context, -coccc <integer>  <integer>: 0 to 2,147,483,647
+-comment-only-changed-content-context, -coccc <integer> <integer>: 0 to 2,147,483,647
                                                         Default: 0
 -comment-only-changed-files, -cocf <boolean>            True if only changed 
                                                         files should be commented. 

--- a/README.md
+++ b/README.md
@@ -125,6 +125,8 @@ Missing a format? Open an issue [here](https://github.com/tomasbjerre/violations
                                                         Default: true
 -comment-only-changed-content, -cocc <boolean>          <boolean>: true or false
                                                         Default: true
+-comment-only-changed-content-context, -coccc <integer>  <integer>: 0 to 2,147,483,647
+                                                        Default: 0
 -comment-only-changed-files, -cocf <boolean>            True if only changed 
                                                         files should be commented. 
                                                         False if all findings should 

--- a/src/main/java/se/bjurr/violations/main/Runner.java
+++ b/src/main/java/se/bjurr/violations/main/Runner.java
@@ -35,6 +35,7 @@ public class Runner {
 
   private List<List<String>> violations;
   private boolean commentOnlyChangedContent;
+  private Integer commentOnlyChangedContentContext;
   private boolean commentOnlyChangedFiles;
   private boolean createCommentWithAllSingleFileComments;
   private boolean createSingleFileComments;
@@ -82,6 +83,10 @@ public class Runner {
 
     final Argument<Boolean> commentOnlyChangedContentArg =
         booleanArgument("-comment-only-changed-content", "-cocc").defaultValue(true).build();
+
+    final Argument<Integer> commentOnlyChangedContentContextArg =
+        IntegerArgument("-comment-only-changed-content-context", "-coccc").defaultValue(0).build();
+
     final Argument<Boolean> shouldCommentOnlyChangedFilesArg =
         booleanArgument("-comment-only-changed-files", "-cocf")
             .defaultValue(true)
@@ -137,6 +142,7 @@ public class Runner {
                   minSeverityArg, //
                   showDebugInfo, //
                   commentOnlyChangedContentArg, //
+                  commentOnlyChangedContentContextArg, //
                   shouldCommentOnlyChangedFilesArg, //
                   createCommentWithAllSingleFileCommentsArg, //
                   createSingleFileCommentsArg, //
@@ -158,6 +164,7 @@ public class Runner {
       this.violations = parsed.get(violationsArg);
       this.minSeverity = parsed.get(minSeverityArg);
       this.commentOnlyChangedContent = parsed.get(commentOnlyChangedContentArg);
+      this.commentOnlyChangedContentContext = parsed.get(commentOnlyChangedContentArg);
       this.commentOnlyChangedFiles = parsed.get(shouldCommentOnlyChangedFilesArg);
       this.createCommentWithAllSingleFileComments =
           parsed.get(createCommentWithAllSingleFileCommentsArg);
@@ -251,6 +258,7 @@ public class Runner {
           .setApiToken(this.apiToken)
           .setTokenType(tokenType)
           .setCommentOnlyChangedContent(this.commentOnlyChangedContent) //
+          .setCommentOnlyChangedContentContext(this.commentOnlyChangedContentContext) //
           .withShouldCommentOnlyChangedFiles(this.commentOnlyChangedFiles) //
           .setCreateCommentWithAllSingleFileComments(
               this.createCommentWithAllSingleFileComments) //
@@ -277,6 +285,8 @@ public class Runner {
         + this.violations
         + ", commentOnlyChangedContent="
         + this.commentOnlyChangedContent
+        + ", commentOnlyChangedContentContext="
+        + this.commentOnlyChangedContentContext
         + ", createCommentWithAllSingleFileComments="
         + this.createCommentWithAllSingleFileComments
         + ", createSingleFileComments="


### PR DESCRIPTION
The changes necessary to provide access to the commentOnlyChangedContentContext from the command line. Changes were inspired from the commentOnlyChangedContent usage. 